### PR TITLE
fix unmet dependencies for apnp-frontend.yml and add python-dev

### DIFF
--- a/apnp-frontend.yml
+++ b/apnp-frontend.yml
@@ -2,6 +2,7 @@
 - hosts: apnp-frontend
 
   roles:
+    - role: common
 
     - role: sane-dns
     - role: squid

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -29,6 +29,7 @@
   with_items:
     - python-setuptools
     - python-pip
+    - python-dev
   tags:
     - common
     - python


### PR DESCRIPTION
1. Fix unmet dependency 'common' role for apnp-frontend.yml
2. Fix unmet dependency 'python-dev' package for building gevent