### PR TITLE
fix: add user for ocserv

### DIFF
--- a/roles/ocserv/tasks/add_user.yml
+++ b/roles/ocserv/tasks/add_user.yml
@@ -1,16 +1,12 @@
 ---
-
-- name: touch /usr/local/etc/ocserv/passwd
-  file: path=/usr/local/etc/ocserv/passwd state=touch
-  when: not ocserv_users
-  tags:
-    - ocserv
-    - add_user
+- name: ensure absent of tmp file for password
+  file: path=/usr/local/etc/ocserv/passwd.in.tmp state=absent
 
 - name: add user for ocserv server
-  lineinfile: line="{{ item.username }} {{ item.password }} *"
-              regexp="{{ item.username }} {{ item.password }} *"
-              dest=/usr/local/etc/ocserv/passwd
+  shell: echo "{{item.password}}" >> /usr/local/etc/ocserv/passwd.in.tmp &&
+         echo "{{item.password}}" >> /usr/local/etc/ocserv/passwd.in.tmp &&
+         ocpasswd -c /usr/local/etc/ocserv/passwd {{item.username}} 0</usr/local/etc/ocserv/passwd.in.tmp &&
+         rm /usr/local/etc/ocserv/passwd.in.tmp
   with_items: ocserv_users
   tags:
     - ocserv

--- a/roles/ocserv/templates/server.tmpl
+++ b/roles/ocserv/templates/server.tmpl
@@ -1,4 +1,4 @@
-cn = "{{ ansible_hostname }}"
+cn = "{{ inventory_hostname }}"
 organization = "VPN Provider"
 serial = 2
 expiration_days = 3650


### PR DESCRIPTION
password in the `passwd` file should be encoded.
the `ocpasswd` tool is responsible for the task