### PR TITLE
Feature/ipsec osx support

### DIFF
--- a/group_vars/ipsec.yml.example
+++ b/group_vars/ipsec.yml.example
@@ -3,8 +3,7 @@ ipsec_enable_l2tp: false
 ipsec_enable_ikev1: true
 ipsec_enable_ikev2: false
 
-# the generated server cert "" should also be imported to osx
-ipsec_osx: false
+# the generated server cert should also be imported to osx
 
 ipsec_domain: "{{ inventory_hostname }}"
 ipsec_bind_ip:  "{{ ansible_default_ipv4.address }}"

--- a/group_vars/ipsec.yml.example
+++ b/group_vars/ipsec.yml.example
@@ -3,6 +3,9 @@ ipsec_enable_l2tp: false
 ipsec_enable_ikev1: true
 ipsec_enable_ikev2: false
 
+# the generated server cert "" should also be imported to osx
+ipsec_osx: false
+
 ipsec_domain: "{{ inventory_hostname }}"
 ipsec_bind_ip:  "{{ ansible_default_ipv4.address }}"
 ipsec_subnet: 10.7.0.0/24

--- a/roles/strongswan/tasks/main.yml
+++ b/roles/strongswan/tasks/main.yml
@@ -62,6 +62,9 @@
 - include: ios8.yml
   when: ipsec_enable_ikev2 and ipsec_gen_ios8_profile
 
+- include: osx.yml
+  when: ipsec_enable_ikev2
+
 - name: make sure /opt/easynat exists
   action: file path=/opt/easynat/ state=directory
   tags:

--- a/roles/strongswan/tasks/osx.yml
+++ b/roles/strongswan/tasks/osx.yml
@@ -1,0 +1,14 @@
+---
+
+- name: create osx config file directory
+  file: path=/var/www/ikev2/osx/ state=directory
+  tags:
+    - ipsec
+    - osx
+
+- name: cp server cert to web server for importing to osx
+  shell: cp /etc/ipsec.d/certs/server_cert.pem /var/www/ikev2/osx/
+  tags:
+    - ipsec
+    - osx
+

--- a/roles/strongswan/templates/ipsec.conf
+++ b/roles/strongswan/templates/ipsec.conf
@@ -76,7 +76,13 @@ conn ikev2
 {% else %}
     rightauth=eap-mschapv2
 {% endif %}
-    #rightsendcert=never   # see note
+
+{% if ipsec_osx %}
+    rightsendcert=always
+{% else %}
+    #rightsendcert=never
+{% endif %}
+
     eap_identity=%any
     auto=add
 {% endif %}

--- a/roles/strongswan/templates/ipsec.conf
+++ b/roles/strongswan/templates/ipsec.conf
@@ -76,11 +76,8 @@ conn ikev2
 {% else %}
     rightauth=eap-mschapv2
 {% endif %}
-{% if ipsec_osx %}
-    rightsendcert=always
-{% else %}
+    leftsendcert=always
     #rightsendcert=never
-{% endif %}
     eap_identity=%any
     auto=add
 {% endif %}

--- a/roles/strongswan/templates/ipsec.conf
+++ b/roles/strongswan/templates/ipsec.conf
@@ -76,13 +76,11 @@ conn ikev2
 {% else %}
     rightauth=eap-mschapv2
 {% endif %}
-
 {% if ipsec_osx %}
     rightsendcert=always
 {% else %}
     #rightsendcert=never
 {% endif %}
-
     eap_identity=%any
     auto=add
 {% endif %}


### PR DESCRIPTION
strongswan  的osx客户端有特殊要求，必须导入证书，及设置leftsendkey=always
见 https://wiki.strongswan.org/projects/strongswan/wiki/MacOSX